### PR TITLE
Auto save window configuration

### DIFF
--- a/windu.el
+++ b/windu.el
@@ -197,7 +197,7 @@
 (defvar windu-window-configuration-5 nil)
 
 (defun windu-set-window-configuration(name)
-  "Save the current window configuration into name"
+  "Save the current window configuration into name."
   (set name (current-window-configuration))
   (message "Window configuration saved"))
 
@@ -390,45 +390,45 @@ After the split, both windows aim to have `windu-fill-column` width."
 
 ;;; window configuration end-user interactive wrapper functions
 (defun windu-set-window-configuration-2 ()
-  "Save the current window configuration to 'windu-window-configuration-2"
+  "Save the current window configuration to 'windu-window-configuration-2."
   (interactive)
   (windu-set-window-configuration 'windu-window-configuration-2))
 
 (defun windu-set-window-configuration-3 ()
-  "Save the current window configuration to 'windu-window-configuration-3"
+  "Save the current window configuration to 'windu-window-configuration-3."
   (interactive)
   (windu-set-window-configuration 'windu-window-configuration-3))
 
 (defun windu-set-window-configuration-4 ()
-  "Save the current window configuration to 'windu-window-configuration-4"
+  "Save the current window configuration to 'windu-window-configuration-4."
   (interactive)
   (windu-set-window-configuration 'windu-window-configuration-4))
 
 (defun windu-set-window-configuration-5 ()
-  "Save the current window configuration to 'windu-window-configuration-5"
+  "Save the current window configuration to 'windu-window-configuration-5."
   (interactive)
   (windu-set-window-configuration 'windu-window-configuration-5))
 
 (defun windu-load-window-configuration-2 ()
-  "Load the window configuration stored in 'windu-window-configuration-2, if one exists"
+  "Load the window configuration stored in 'windu-window-configuration-2, if one exists."
   (interactive)
   (windu-load-window-configuration windu-window-configuration-2)
   (message "Window configuration loaded"))
 
 (defun windu-load-window-configuration-3 ()
-  "Load the window configuration stored in 'windu-window-configuration-3, if one exists"
+  "Load the window configuration stored in 'windu-window-configuration-3, if one exists."
   (interactive)
   (windu-load-window-configuration windu-window-configuration-3)
   (message "Window configuration loaded"))
 
 (defun windu-load-window-configuration-4 ()
-  "Load the window configuration stored in 'windu-window-configuration-4, if one exists"
+  "Load the window configuration stored in 'windu-window-configuration-4, if one exists."
   (interactive)
   (windu-load-window-configuration windu-window-configuration-4)
   (message "Window configuration loaded"))
 
 (defun windu-load-window-configuration-5 ()
-  "Load the window configuration stored in 'windu-window-configuration-5, if one exists"
+  "Load the window configuration stored in 'windu-window-configuration-5, if one exists."
   (interactive)
   (windu-load-window-configuration windu-window-configuration-5)
   (message "Window configuration loaded"))

--- a/windu.el
+++ b/windu.el
@@ -58,7 +58,7 @@
             (define-key map (kbd "{") 'windu-order-height-bottom)
             (define-key map (kbd "}") 'windu-order-height-top)
             ;; Splits / Group Orders
-            (define-key map (kbd "3") 'windu-split-window-best-effort)
+            (define-key map (kbd "b") 'windu-split-window-best-effort)
             (define-key map (kbd "r") 'windu-split-window-right)
             (define-key map (kbd "l") 'windu-split-window-left)
             (define-key map (kbd "+") 'windu-order-fill-many-windows)
@@ -71,6 +71,15 @@
             (define-key map (kbd "C-.") 'windu-bring-right)
             (define-key map (kbd "C-<") 'windu-bring-top)
             (define-key map (kbd "C->") 'windu-bring-bottom)
+            ;; Window Configuration
+            (define-key map (kbd "2") 'windu-set-window-configuration-2)
+            (define-key map (kbd "3") 'windu-set-window-configuration-3)
+            (define-key map (kbd "4") 'windu-set-window-configuration-4)
+            (define-key map (kbd "5") 'windu-set-window-configuration-5)
+            (define-key map (kbd "@") 'windu-load-window-configuration-2)
+            (define-key map (kbd "#") 'windu-load-window-configuration-3)
+            (define-key map (kbd "$") 'windu-load-window-configuration-4)
+            (define-key map (kbd "%") 'windu-load-window-configuration-5)
             ;; Info
             (define-key map (kbd "i") 'windu-echo-size)
             map)
@@ -180,11 +189,28 @@
            (windu-swap-buffers other-window window)
            other-window))))
 
-;;; end-user interactive wrapper functions
+;;; window configuration hotkeys
 
+(defvar windu-window-configuration-2 nil)
+(defvar windu-window-configuration-3 nil)
+(defvar windu-window-configuration-4 nil)
+(defvar windu-window-configuration-5 nil)
+
+(defun windu-set-window-configuration(name)
+  "Save the current window configuration into name"
+  (set name (current-window-configuration))
+  (message "Window configuration saved"))
+
+(defun windu-load-window-configuration(name)
+  "Load the window configuration corresponding to name."
+  (if name (progn (set-window-configuration name) (message "Window configuration loaded"))
+    (message "Saved configuration not found")))
+
+;;; end-user interactive wrapper functions
 (defun windu-transient-activate ()
   "Begins a new nudge action."
   (interactive)
+  (message "Entering windu mode")
   (windu-transient-mode 1))
 
 (defun windu-transient-abort ()
@@ -362,10 +388,55 @@ After the split, both windows aim to have `windu-fill-column` width."
   (interactive)
   (select-window (windu-swap-buffers-in-direction 'below)))
 
+;;; window configuration end-user interactive wrapper functions
+(defun windu-set-window-configuration-2 ()
+  "Save the current window configuration to 'windu-window-configuration-2"
+  (interactive)
+  (windu-set-window-configuration 'windu-window-configuration-2))
+
+(defun windu-set-window-configuration-3 ()
+  "Save the current window configuration to 'windu-window-configuration-3"
+  (interactive)
+  (windu-set-window-configuration 'windu-window-configuration-3))
+
+(defun windu-set-window-configuration-4 ()
+  "Save the current window configuration to 'windu-window-configuration-4"
+  (interactive)
+  (windu-set-window-configuration 'windu-window-configuration-4))
+
+(defun windu-set-window-configuration-5 ()
+  "Save the current window configuration to 'windu-window-configuration-5"
+  (interactive)
+  (windu-set-window-configuration 'windu-window-configuration-5))
+
+(defun windu-load-window-configuration-2 ()
+  "Load the window configuration stored in 'windu-window-configuration-2, if one exists"
+  (interactive)
+  (windu-load-window-configuration windu-window-configuration-2)
+  (message "Window configuration loaded"))
+
+(defun windu-load-window-configuration-3 ()
+  "Load the window configuration stored in 'windu-window-configuration-3, if one exists"
+  (interactive)
+  (windu-load-window-configuration windu-window-configuration-3)
+  (message "Window configuration loaded"))
+
+(defun windu-load-window-configuration-4 ()
+  "Load the window configuration stored in 'windu-window-configuration-4, if one exists"
+  (interactive)
+  (windu-load-window-configuration windu-window-configuration-4)
+  (message "Window configuration loaded"))
+
+(defun windu-load-window-configuration-5 ()
+  "Load the window configuration stored in 'windu-window-configuration-5, if one exists"
+  (interactive)
+  (windu-load-window-configuration windu-window-configuration-5)
+  (message "Window configuration loaded"))
+
 (defun windu-setup-keybindings (&optional mode-prefix)
   "Set up keybinding for `windu-transient-mode` on MODE-PREFIX. Defaults to 'C-x C-m'."
   (interactive)
-  (let ((mode-prefix (or mode-prefix (kbd "C-x C-m"))))
+  (let ((mode-prefix (or mode-prefix (kbd "C-x C-x"))))
     (global-set-key mode-prefix 'windu-transient-activate)))
 
 (provide 'windu)

--- a/windu.el
+++ b/windu.el
@@ -196,6 +196,9 @@
 (defvar windu-window-configuration-4 nil)
 (defvar windu-window-configuration-5 nil)
 
+(defvar windu-auto-save-window-configuration-1 nil)
+(defvar windu-auto-save-window-configuration-0 nil)
+
 (defun windu-set-window-configuration(name)
   "Save the current window configuration into name."
   (set name (current-window-configuration))
@@ -432,6 +435,44 @@ After the split, both windows aim to have `windu-fill-column` width."
   (interactive)
   (windu-load-window-configuration windu-window-configuration-5)
   (message "Window configuration loaded"))
+
+(defun windu-auto-save-set-window-configuration-1()
+  "Intended to intercept the default binding for delete-other-windows. Save the current \
+   window configuration to 'windu-auto-save-window-configuration-1 and then continue \
+   executing delete-other-windows."
+  (interactive)
+  (windu-set-window-configuration 'windu-auto-save-window-configuration-1)
+  (delete-other-windows)
+  (message "Window configuration auto-saved."))
+
+(defun windu-auto-save-set-window-configuration-0()
+  "Intended to intercept the default binding for delete-window. Save the current \
+   window configuration to 'windu-auto-save-window-configuration-0 and then continue \
+   executing delete-other-windows."
+  (interactive)
+  (windu-set-window-configuration 'windu-auto-save-window-configuration-0)
+  (delete-window)
+  (message "Window configuration auto-saved."))
+
+(defun windu-auto-save-load-window-configuration-1 ()
+  "Load the window configuration stored in 'windu-auto-save-load-window-configuration-1, \
+   if one exists."
+  (interactive)
+  (windu-load-window-configuration windu-auto-save-window-configuration-1)
+  (message "Window configuration loaded"))
+
+(defun windu-auto-save-load-window-configuration-0 ()
+  "Load the window configuration stored in 'windu-auto-save-load-window-configuration-0, \
+   if one exists."
+  (interactive)
+  (windu-load-window-configuration windu-auto-save-window-configuration-0)
+  (message "Window configuration loaded"))
+
+(global-set-key (kbd "C-x 1") 'windu-auto-save-set-window-configuration-1)
+(global-set-key (kbd "C-x !") 'windu-auto-save-load-window-configuration-1)
+
+(global-set-key (kbd "C-x 0") 'windu-auto-save-set-window-configuration-0)
+(global-set-key (kbd "C-x )") 'windu-auto-save-load-window-configuration-0)
 
 (defun windu-setup-keybindings (&optional mode-prefix)
   "Set up keybinding for `windu-transient-mode` on MODE-PREFIX. Defaults to 'C-x C-m'."


### PR DESCRIPTION
Add functionality to auto-save the window configuration when using C-x 1 and C-x 0.

This PR builds on the previous one. Creating this PR so we can discuss the key binding. The current global override works if I M-x eval-buffer to the windu.el file, but it doesn't work if I open a fresh emacs. I haven't debugged this yet.